### PR TITLE
286235: Update application helm values to use memory and cpu tiers

### DIFF
--- a/helm/ffc-ffd-frontend-poc/Chart.yaml
+++ b/helm/ffc-ffd-frontend-poc/Chart.yaml
@@ -5,5 +5,5 @@ name: ffc-ffd-frontend-poc
 version: 1.0.0
 dependencies:
 - name: adp-helm-library
-  version: 1.0.9-prerelease4
+  version: ^1.0.0
   repository: https://raw.githubusercontent.com/defra/adp-helm-repository/main/adp-helm-library

--- a/helm/ffc-ffd-frontend-poc/Chart.yaml
+++ b/helm/ffc-ffd-frontend-poc/Chart.yaml
@@ -5,5 +5,5 @@ name: ffc-ffd-frontend-poc
 version: 1.0.0
 dependencies:
 - name: adp-helm-library
-  version: ^1.0.0
+  version: 1.0.9-prerelease4
   repository: https://raw.githubusercontent.com/defra/adp-helm-repository/main/adp-helm-library

--- a/helm/ffc-ffd-frontend-poc/values.yaml
+++ b/helm/ffc-ffd-frontend-poc/values.yaml
@@ -14,10 +14,7 @@ appInsights:
 deployment: {}
 
 container:
-  requestMemory: 100Mi
-  requestCpu: 100m
-  limitMemory: 100Mi
-  limitCpu: 100m
+  memCpuTier: M
   port: 3000
 
 livenessProbe:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ffd-frontend-poc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ffd-frontend-poc",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@hapi/hapi": "21.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ffd-frontend-poc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Proof of concept FFD frontend",
   "homepage": "github.com?owner=defra&repo=ffc-ffd-frontend-poc&organization=defra",
   "main": "app/index.js",


### PR DESCRIPTION
# **What this PR does / why we need it**:
This change is to update the application helm values to now use memory and cpu tiers.  The memory and CPU tiers are part of this PR - https://github.com/DEFRA/adp-helm-library/pull/20

[AB#293218](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/293218)

# Testing
Testing has been carried out against the SND1 cluster to make sure the correct cpu memory tier values are being used in the deployment manifest and Flux is reconciling correctly

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
